### PR TITLE
Add the '-y' flag to apt-get update/upgrade commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-slim
 
-RUN apt-get update && apt-get upgrade
+RUN apt-get update -y && apt-get upgrade -y
 RUN apt-get install -y build-essential cmake python3-opencv
 
 WORKDIR /code


### PR DESCRIPTION
Otherwise, the Dockerfile crashes:

```
1.171 Get:6 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [169 kB]
2.081 Fetched 9225 kB in 2s (4966 kB/s)
2.081 Reading package lists...
2.529 Reading package lists...
2.976 Building dependency tree...
3.087 Reading state information...
3.118 Calculating upgrade...
3.523 The following packages will be upgraded:
3.523   base-files bash bsdutils debian-archive-keyring debianutils libblkid1
3.523   libc-bin libc6 libgnutls30 libgssapi-krb5-2 libk5crypto3 libkrb5-3
3.524   libkrb5support0 libmount1 libpam-modules libpam-modules-bin libpam-runtime
3.524   libpam0g libseccomp2 libsmartcols1 libssl3 libsystemd0 libudev1 libuuid1
3.525   mount openssl perl-base tar tzdata usr-is-merged util-linux util-linux-extra
3.532 32 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
3.532 Need to get 16.4 MB of archives.
3.532 After this operation, 38.9 kB of additional disk space will be used.
3.532 Do you want to continue? [Y/n] Abort.
------
Dockerfile:3
--------------------
   1 |     FROM python:3.7-slim
   2 |
   3 | >>> RUN apt-get update && apt-get upgrade
   4 |     RUN apt-get install -y build-essential cmake python3-opencv
   5 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update && apt-get upgrade" did not complete successfully: exit code: 1
```